### PR TITLE
GCM-234 Add parameter for optional camera orientation lock

### DIFF
--- a/sample-app/shared/src/commonMain/kotlin/MainView.kt
+++ b/sample-app/shared/src/commonMain/kotlin/MainView.kt
@@ -104,6 +104,7 @@ fun MainView() {
                         types = listOf(CodeType.QR),
                         cameraPosition = cameraPosition,
                         defaultOrientation = CameraOrientation.LANDSCAPE,
+                        forcedCameraOrientation = CameraOrientation.LANDSCAPE,
                         scanningEnabled = scanningActive,
                         scanRegionScale = scanRegionScale
                     )

--- a/scanner/src/androidMain/kotlin/Scanner.android.kt
+++ b/scanner/src/androidMain/kotlin/Scanner.android.kt
@@ -27,6 +27,7 @@ actual fun Scanner(
     types: List<CodeType>,
     cameraPosition: CameraPosition,
     defaultOrientation: CameraOrientation?,
+    forcedCameraOrientation: CameraOrientation?, // not used on Android
     scanningEnabled: Boolean,
     scanRegionScale: ScanRegionScale,
 ) {

--- a/scanner/src/commonMain/kotlin/Scanner.kt
+++ b/scanner/src/commonMain/kotlin/Scanner.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
  *                  Return false if scanning should continue.
  * @param cameraPosition Camera position (front/back) to use.
  * @param defaultOrientation Default orientation of the camera.
+ * @param forcedCameraOrientation If set, forces the camera to stay in this orientation regardless of device rotation.
  * @param scanningEnabled Whether scanning is active.
  * @param scanRegionScale Scale to which the active scan region should be narrowed down compared to the size of the visible camera feed.
  */
@@ -30,6 +31,7 @@ expect fun Scanner(
     types: List<CodeType>,
     cameraPosition: CameraPosition = CameraPosition.BACK,
     defaultOrientation: CameraOrientation? = null,
+    forcedCameraOrientation: CameraOrientation? = null,
     scanningEnabled: Boolean,
     scanRegionScale: ScanRegionScale = ScanRegionScale(1.0f, 1.0f)
 )
@@ -44,6 +46,7 @@ expect fun Scanner(
  * @param permissionText Text to show if permission was denied.
  * @param openSettingsLabel Label to show on the "Go to settings" Button
  * @param defaultOrientation Default orientation of the camera.
+ * @param forcedCameraOrientation If set, forces the camera to stay in this orientation regardless of device rotation.
  * @param scanningEnabled Whether scanning is active.
  * @param scanRegionScale Scale to which the active scan region should be narrowed down compared to the size of the visible camera feed.
  */
@@ -56,6 +59,7 @@ fun ScannerWithPermissions(
     permissionText: String = "Camera is required for QR Code scanning",
     openSettingsLabel: String = "Open Settings",
     defaultOrientation: CameraOrientation?,
+    forcedCameraOrientation: CameraOrientation? = null,
     scanningEnabled: Boolean,
     scanRegionScale: ScanRegionScale = ScanRegionScale(1.0f, 1.0f)
 ) {
@@ -76,6 +80,7 @@ fun ScannerWithPermissions(
             }
         },
         defaultOrientation,
+        forcedCameraOrientation,
         scanningEnabled,
         scanRegionScale
     )
@@ -90,6 +95,7 @@ fun ScannerWithPermissions(
  *                  Return false if scanning should continue.
  * @param permissionDeniedContent Content to show if permission was denied.
  * @param defaultOrientation Default orientation of the camera.
+ * @param forcedCameraOrientation If set, forces the camera to stay in this orientation regardless of device rotation.
  * @param scanningEnabled Whether scanning is active.
  * @param scanRegionScale Scale to which the active scan region should be narrowed down compared to the size of the visible camera feed.
  */
@@ -101,6 +107,7 @@ fun ScannerWithPermissions(
     cameraPosition: CameraPosition,
     permissionDeniedContent: @Composable (CameraPermissionState) -> Unit,
     defaultOrientation: CameraOrientation?,
+    forcedCameraOrientation: CameraOrientation? = null,
     scanningEnabled: Boolean,
     scanRegionScale: ScanRegionScale = ScanRegionScale(1.0f, 1.0f)
 ) {
@@ -119,6 +126,7 @@ fun ScannerWithPermissions(
             onScanned = onScanned,
             cameraPosition = cameraPosition,
             defaultOrientation = defaultOrientation,
+            forcedCameraOrientation = forcedCameraOrientation,
             scanningEnabled = scanningEnabled,
             scanRegionScale = scanRegionScale
         )

--- a/scanner/src/iosMain/kotlin/Scanner.ios.kt
+++ b/scanner/src/iosMain/kotlin/Scanner.ios.kt
@@ -22,6 +22,7 @@ actual fun Scanner(
     types: List<CodeType>,
     cameraPosition: CameraPosition,
     defaultOrientation: CameraOrientation?,
+    forcedCameraOrientation: CameraOrientation?,
     scanningEnabled: Boolean,
     scanRegionScale: ScanRegionScale,
 ) {
@@ -33,6 +34,7 @@ actual fun Scanner(
         allowedMetadataTypes = types.toFormat(),
         cameraPosition = cameraPosition,
         defaultOrientation = defaultOrientation,
+        forcedCameraOrientation = forcedCameraOrientation,
         scanningEnabled = scanningEnabled,
         scanRegionScale = scanRegionScale
     )

--- a/scanner/src/jvmMain/kotlin/Scanner.jvm.kt
+++ b/scanner/src/jvmMain/kotlin/Scanner.jvm.kt
@@ -11,6 +11,7 @@ actual fun Scanner(
     types: List<CodeType>,
     cameraPosition: CameraPosition,
     defaultOrientation: CameraOrientation?,
+    forcedCameraOrientation: CameraOrientation?,
     scanningEnabled: Boolean,
     scanRegionScale: ScanRegionScale,
 ) {


### PR DESCRIPTION
Forcing specific orientation (landscape or portrait) for the video feed regardless of device orientation - extra parameter `forcedCameraOrientation`
