### PR TITLE
GCM-227 fix for the blinking and resuming the capture session smoothly based on scanning enabled/disabled. Fix for the crash in the android devices.

### DIFF
--- a/scanner/src/androidMain/kotlin/BarcodeAnalyzer.kt
+++ b/scanner/src/androidMain/kotlin/BarcodeAnalyzer.kt
@@ -15,6 +15,7 @@ import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.common.InputImage
 import java.io.ByteArrayOutputStream
+import kotlin.math.max
 
 class BarcodeAnalyzer(
     formats: Int = Barcode.FORMAT_QR_CODE,
@@ -35,8 +36,8 @@ class BarcodeAnalyzer(
             val cropRegion = getCameraImageCropForScanRegion(
                 imageWidth = image.width,
                 imageHeight = image.height,
-                uiWidth = cameraFeedSize.width,
-                uiHeight = cameraFeedSize.height,
+                uiWidth = max(cameraFeedSize.width,1f),
+                uiHeight = max(cameraFeedSize.height,1f),
                 scanRegionHorizontalScale = scanRegionScale.horizontal,
                 scanRegionVerticalScale = scanRegionScale.vertical
             )


### PR DESCRIPTION
There is crash in the BarcodeAnalyser due to bitmap size being zero. This has been fixed in this PR. It is now possible to do multiple scans without any blinking.